### PR TITLE
fix: footer social icons invisible in their circles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -274,6 +274,7 @@ img {
     height: 2.5em;
     border-radius: 50%;
     background: #404040;
+    color: #FFF;
 }
 
 .social-icon svg {


### PR DESCRIPTION
The SVG paths use fill="currentColor", which resolves the CSS `color` property, not `fill`. The `.social-icon svg { fill: #FFF }` rule never applied to the paths, so currentColor fell back to `footer a`'s color (#404040) — the same shade as the circle background, making the icons invisible.

Set `color: #FFF` on `.social-icon` so currentColor resolves to white.