### PR TITLE
fix: clear Cecil cache before deploy build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,5 +18,6 @@ serve: ## Run server & watch
 
 .PHONY: deploy
 deploy: ## Deploy the project
+	rm -rf .cache .cecil
 	BOX_REQUIREMENT_CHECKER=0 php cecil.phar build
 	rsync -avr --delete-after --delete-excluded _site/ deploy:/var/www/odolbeau.fr/


### PR DESCRIPTION
Production JSON-LD (WebSite/ItemList) was resolving to http://localhost:8000 instead of https://odolbeau.fr. Root cause: Cecil's vendored partials/jsonld.js.twig wraps the WebSite block in a Twig {% cache %} tag keyed only on 'jsonld_website__<cecil.version>' — never on the base URL or environment. If .cache/.cecil from a prior `make serve` (dev, localhost baseurl) survives to the next `make deploy` build, the stale localhost fragment ships to production verbatim.

Not patchable here (vendored cecil.phar template) — workaround is to always build deploy artifacts from a clean cache. Verified locally: after `rm -rf .cache .cecil` + rebuild, all JSON-LD urls resolve to https://odolbeau.fr as expected.