### PR TITLE
fix: remove literal backslash from talk title to fix JSON-LD

### DIFF
--- a/pages/talks/2024-10-10-throw-new-exception-oui-mais-laquelle.md
+++ b/pages/talks/2024-10-10-throw-new-exception-oui-mais-laquelle.md
@@ -1,7 +1,7 @@
 ---
 layout: talk
 date: 2024-10-10
-title: Throw new \Exception(); Oui, mais laquelle ?
+title: Throw new Exception(); Oui, mais laquelle ?
 event: Forum PHP 2024
 speakerdeck: 9ae6d47af9c3434f9ccaeddf6d427c40
 ratio: 1.77777777777778


### PR DESCRIPTION
The title "Throw new \Exception(); ..." contained a raw backslash. Cecil's vendored jsonld.js.twig interpolates page.title into the JSON-LD <script> block using Twig's |e (html) filter, which does not JSON-escape backslashes. The unescaped \E sequence made the entire WebSite/ItemList/WebPage/BreadcrumbList JSON-LD array on this page invalid JSON.

Verified: fresh build + JSON parse of the ld+json block now succeeds.