### PR TITLE
fix: use page lang for <html> attribute, add self-referencing hreflang

### DIFF
--- a/layouts/blog/page.html.twig
+++ b/layouts/blog/page.html.twig
@@ -2,6 +2,9 @@
 
         {% block head %}
             {{ parent() }}
+            {%- if page.reflang is defined ~%}
+            <link rel="alternate" hreflang="{{ page.lang|default(site.language) }}" href="{{ url(page, {canonical: true}) }}">
+            {%- endif ~%}
             {%- for p in site.allpages -%}
                 {%- if page.reflang is defined and p.reflang is defined and p.reflang == page.reflang and p.lang != page.lang ~%}
             <link rel="alternate" hreflang="{{ p.lang }}" href="{{ url(p, {canonical: true}) }}">

--- a/layouts/page.html.twig
+++ b/layouts/page.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.language }}">
+<html lang="{{ page.lang|default(site.language) }}">
     <head>
         {%- block head ~%}
             <meta charset="UTF-8">


### PR DESCRIPTION
- <html lang> was hardcoded to site.language, ignoring per-page lang front matter (e.g. FR posts rendered lang="en").
- Bilingual blog posts emitted hreflang links to the alternate translation and x-default, but never to themselves, which violates Google's requirement that every page in a translated set self-reference.