### PR TITLE
perf: add font-display: swap to @font-face rules

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -2,6 +2,7 @@
   font-family: 'Lora';
   font-style: normal;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/Lora-Bold.woff2') format('woff2');
 }
 
@@ -9,6 +10,7 @@
   font-family: 'Lora';
   font-style: italic;
   font-weight: 700;
+  font-display: swap;
   src: url('../fonts/Lora-BoldItalic.woff2') format('woff2');
 }
 
@@ -16,6 +18,7 @@
   font-family: 'Lora';
   font-style: italic;
   font-weight: 400;
+  font-display: swap;
   src: url('../fonts/Lora-Italic.woff2') format('woff2');
 }
 
@@ -23,5 +26,6 @@
   font-family: 'Lora';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url('../fonts/Lora-Regular.woff2') format('woff2');
 }


### PR DESCRIPTION
Prevents invisible text during font load (FOIT) by showing a fallback font immediately and swapping to Lora once loaded.