### PR TITLE
fix: add alt text and explicit width/height to avatar image

### DIFF
--- a/layouts/page.html.twig
+++ b/layouts/page.html.twig
@@ -82,7 +82,7 @@
                         <div class="avatar-container">
                             <div class="avatar-img-border">
                                 <a href="/">
-                                    <img class="avatar-img" src="{{ asset('images/avatar-icon.png') }}" />
+                                    <img class="avatar-img" src="{{ asset('images/avatar-icon.png') }}" alt="{{ site.author.name }}" width="100" height="100" />
                                 </a>
                             </div>
                         </div>


### PR DESCRIPTION
## Why

SEO audit finding: the nav avatar `<img>` had no `alt` text and no
explicit `width`/`height`, which hurts accessibility/crawlability and
can cause a layout shift before CSS applies.

## What changed

`layouts/page.html.twig`:
- `alt="{{ site.author.name }}"` — reuses the existing `site.author.name`
  from `cecil.yml` instead of a hardcoded string.
- `width="100" height="100"` — the PNG's actual intrinsic size. CSS still
  drives the responsive rendering (`.avatar-img { width/height: 100% }`),
  this just gives the browser the right aspect ratio up front.

Verified with a local `cecil.phar build`:
```html
<img class="avatar-img" src="/images/avatar-icon.ec98fdd62875a5a1715e8ef58324b247.png" alt="Olivier Dolbeau" width="100" height="100" />
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)