### PR TITLE
fix: metric-match Lora fallback font + preload to kill homepage CLS

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -6,6 +6,37 @@
   src: url('../fonts/Lora-Bold.woff2') format('woff2');
 }
 
+/* Metric-matched fallback for 'Lora', used by body { font-family: 'Lora', 'Lora Fallback', ... }
+   while the Lora webfont is still loading (font-display: swap paints with this fallback first).
+   ascent-override/descent-override/size-adjust are tuned so this fallback occupies the same
+   line-box height and average glyph width as Lora itself, so swapping the real font in doesn't
+   reflow the page. Without this, the fallback (Times New Roman-ish) renders visibly shorter/
+   narrower than Lora, causing the CLS regression introduced by font-display: swap.
+   Values computed from each Lora weight's own OS/2 metrics against Liberation Serif, which is
+   metrically compatible with Times New Roman (same glyph advance widths) — same method used by
+   tools like Fontaine/Capsize, just run by hand against the actual font files in static/fonts. */
+@font-face {
+  font-family: 'Lora Fallback';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Liberation Serif'), local('Times New Roman');
+  ascent-override: 92.79%;
+  descent-override: 25.27%;
+  line-gap-override: 0%;
+  size-adjust: 108.41%;
+}
+
+@font-face {
+  font-family: 'Lora Fallback';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Liberation Serif'), local('Times New Roman');
+  ascent-override: 93.94%;
+  descent-override: 25.59%;
+  line-gap-override: 0%;
+  size-adjust: 107.09%;
+}
+
 @font-face {
   font-family: 'Lora';
   font-style: italic;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,7 +1,9 @@
 /* --- General --- */
 
 body {
-    font-family: 'Lora', 'Times New Roman', serif;
+    /* 'Lora Fallback' is a metric-matched stand-in (see fonts.css) that occupies the same
+       line-box height/width as Lora, so the font-display: swap below doesn't reflow the page. */
+    font-family: 'Lora', 'Lora Fallback', 'Times New Roman', serif;
     font-size: 22px;
     color: #404040;
     position: relative;

--- a/layouts/page.html.twig
+++ b/layouts/page.html.twig
@@ -41,6 +41,13 @@
                 <!-- Bootstrap core CSS: render-blocking, needed for the above-the-fold layout (grid, nav) -->
                 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" referrerpolicy="no-referrer">
 
+                <!-- Preload the two Lora weights used above the fold (body text + <strong>/<b>), so the
+                     browser fetches them immediately instead of discovering them only once it parses
+                     the @font-face rules in fonts.css below. Paired with the metric-matched fallback in
+                     fonts.css to fix the CLS regression that font-display: swap introduced. -->
+                <link rel="preload" href="/fonts/Lora-Regular.woff2" as="font" type="font/woff2" crossorigin>
+                <link rel="preload" href="/fonts/Lora-Bold.woff2" as="font" type="font/woff2" crossorigin>
+
                 <!-- Site CSS, bundled into a single request: also render-blocking, needed for above-the-fold layout/type -->
                 <link rel="stylesheet" href="{{ asset(['css/main.css', 'css/fonts.css']) }}">
 


### PR DESCRIPTION
## Problem

The SEO/perf re-audit flagged a new CLS regression on the homepage (0.163, "Needs Improvement"), caused as a side effect of the previous `font-display: swap` fix: text paints with the fallback font before Lora loads, and since the fallback (`Times New Roman`/system serif) has different line-box metrics than Lora, the about-text block shifts visibly on swap-in.

## Fix

- **`assets/css/fonts.css`** — add a `'Lora Fallback'` `@font-face` (weights 400/700) using `ascent-override`/`descent-override`/`line-gap-override`/`size-adjust`, computed from Lora's own OS/2 metrics (via `fontTools`) against Liberation Serif, which is metrically compatible with Times New Roman — same technique tools like Fontaine/Capsize automate.
- **`assets/css/main.css`** — insert `'Lora Fallback'` into the `body` font stack between `'Lora'` and `'Times New Roman'`, so the fallback occupies the same box Lora will.
- **`layouts/page.html.twig`** — `<link rel="preload">` for `Lora-Regular.woff2`/`Lora-Bold.woff2`, the two weights used above the fold in the homepage about-text (`<strong>`/`<b>`), shortening the window the fallback is shown at all.

## Verification

- `php cecil.phar build` succeeds.
- Compiled `_site/styles.*.css` contains the new `@font-face` rules and updated `body` font stack.
- Preload hrefs (`/fonts/Lora-Regular.woff2`, `/fonts/Lora-Bold.woff2`) resolve to files actually present in `_site/fonts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)