### PR TITLE
fix: add alt text and explicit width/height to avatar image

### DIFF
--- a/layouts/page.html.twig
+++ b/layouts/page.html.twig
@@ -82,7 +82,7 @@
                         <div class="avatar-container">
                             <div class="avatar-img-border">
                                 <a href="/">
-                                    <img class="avatar-img" src="{{ asset('images/avatar-icon.png') }}" />
+                                    <img class="avatar-img" src="{{ asset('images/avatar-icon.png') }}" alt="{{ site.author.name }}" width="100" height="100" />
                                 </a>
                             </div>
                         </div>


### PR DESCRIPTION
Fixes an SEO audit finding on the nav avatar <img>: no alt text and no explicit dimensions, both of which help crawlers and avoid layout shift before CSS applies.

- alt reuses site.author.name instead of a hardcoded string
- width/height set to the PNG's intrinsic 100x100; CSS still drives the actual responsive rendering