### PR TITLE
fix: derive BlogPosting dateModified from explicit updated: front matter

### DIFF
--- a/layouts/blog/page.html.twig
+++ b/layouts/blog/page.html.twig
@@ -29,8 +29,13 @@
               {%- if page.description|default is not empty ~%}
               "description": "{{ page.description|replace({"\n": ' '})|trim|e('js') }}",
               {%- endif ~%}
+              {#- page.updated always resolves to *something* (Cecil falls back to the file's
+                  filesystem mtime when no `updated:` front-matter key is set), so it can't be
+                  used to detect "was dateModified actually declared?". page.fmVariables is the
+                  raw, unmerged front-matter dict, so .updated is only present there when the
+                  post explicitly sets it ~#}
               "datePublished": "{{ page.date|date('c') }}",
-              "dateModified": "{{ page.date|date('c') }}",
+              "dateModified": "{{ (page.fmVariables.updated|default(page.date))|date('c') }}",
               "inLanguage": "{{ page.lang|default(site.language) }}",
               "url": "{{ url(page, {canonical: true}) }}",
               "author": {

--- a/pages/blog/2011-08-08-la-puissance-des-data-providers-de-phpunit.md
+++ b/pages/blog/2011-08-08-la-puissance-des-data-providers-de-phpunit.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "La puissance des data providers de PHPUnit"
+updated: 2026-08-15
 lang: fr
 description: La puissance des data providers de PHPUnit
 tags: [tests unitaires, phpunit, data providers]

--- a/pages/blog/2024-12-02-phpunit-data-provider-usage.md
+++ b/pages/blog/2024-12-02-phpunit-data-provider-usage.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: À quel moment est-il pertinent d'utiliser un data provider PHPUnit ?
+updated: 2026-08-15
 lang: fr
 subtitle: Ou plutôt, quand faut-il éviter d'en utiliser un !
 description: Quand l'utilisation d'un data provider PHPUnit est-elle pertinente et quand ne l'est-elle pas.

--- a/pages/blog/2026-02-04-announcing-tested-routes-checker-bundle-fr.md
+++ b/pages/blog/2026-02-04-announcing-tested-routes-checker-bundle-fr.md
@@ -1,6 +1,7 @@
 ---
 title: 🚀 Découvrez TestedRoutesCheckerBundle !
 date: 2026-02-04
+updated: 2026-08-15
 published: true
 lang: fr
 reflang: announcing-tested-routes-checker-bundle

--- a/pages/blog/2026-02-04-announcing-tested-routes-checker-bundle.md
+++ b/pages/blog/2026-02-04-announcing-tested-routes-checker-bundle.md
@@ -1,6 +1,7 @@
 ---
 title: 🚀 Introducing TestedRoutesCheckerBundle!
 date: 2026-02-04
+updated: 2026-08-15
 published: true
 lang: en
 reflang: announcing-tested-routes-checker-bundle


### PR DESCRIPTION
## Why

SEO audit finding: `dateModified` in the `BlogPosting` JSON-LD block was
hardcoded to `page.date` (same value as `datePublished`), so every post
falsely claimed to have never been modified since publish, regardless of
real edits.

## What changed

`layouts/blog/page.html.twig`:
- `dateModified` now reads `page.fmVariables.updated` instead of `page.date`.
- `page.updated` (Cecil's merged/computed property) can't be used for
  this: Cecil transparently falls back to the file's filesystem mtime
  when no `updated:` front-matter key is set, so `page.updated|default(page.date)`
  never actually falls through — confirmed this was fabricating
  `dateModified` values (e.g. a post published in 2020 was showing
  `dateModified: 2026-01-05` off a stale local checkout mtime, with zero
  relation to any real content edit).
- `page.fmVariables` is Cecil's raw, unmerged front-matter dict, so
  `.updated` is only present there when a post explicitly declares it —
  giving a clean fallback to `datePublished` for untouched posts.

Front matter: backfilled `updated: 2026-08-15` on the four posts actually
edited this session, so their `dateModified` reflects reality instead of
silently falling back to `datePublished`:
- `2011-08-08-la-puissance-des-data-providers-de-phpunit.md`
- `2024-12-02-phpunit-data-provider-usage.md`
- `2026-02-04-announcing-tested-routes-checker-bundle.md` (en)
- `2026-02-04-announcing-tested-routes-checker-bundle-fr.md`

## Verification

Local `cecil.phar build`, comparing `datePublished`/`dateModified` in the
rendered JSON-LD:

| post | datePublished | dateModified |
|---|---|---|
| bundle post (en/fr) — has `updated:` | 2026-02-04 | 2026-08-15 ✅ |
| PHPUnit posts (2011/2024) — has `updated:` | 2011-08-08 / 2024-12-02 | 2026-08-15 ✅ |
| untouched post, no `updated:` (`doctrine-migrations-rollup`) | 2020-05-07 | 2020-05-07 ✅ (no fabricated date) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)